### PR TITLE
Update key_figure.csv

### DIFF
--- a/key_figure.csv
+++ b/key_figure.csv
@@ -20,12 +20,12 @@ Y,美坂 香里,Misaka Kaori,3,1,164,48,B,83,55,81,D,KAN_KAO.png,KAN_KAO.gif,Kan
 Y,天野 美汐,Amano Mishio,12,6,159,44,A,80,53,79,D,KAN_MIS.png,KAN_MIS.png,Kanon,坂本 真綾,幾星霜の観測者,http://zh.wikipedia.org/wiki/Kanon
 N,,,,,,,,,,,,,,,,,
 Y,古河 渚,Furukawa Nagisa,12,24,155,43,A,80,55,81,B,CLA_NAG.png,,CLANNAD,中原 麻衣,slk000/JimRaynor,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
-Y,藤林 杏,Fujibayashi Kyō,9,9,160,46,O,82,56,82,C,CLA_KYO.png,,CLANNAD,広橋 涼,slk000/JimRaynor,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
+Y,藤林 杏,Fujibayashi Kyō,9,9,160,46,O,82,56,82,D,CLA_KYO.png,,CLANNAD,広橋 涼,slk000/JimRaynor,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
 Y,一ノ瀬 ことみ,Ichinose Kotomi,5,13,160,48,A,88,58,85,F,CLA_KOT.png,,CLANNAD,能登 麻美子,slk000,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
 Y,坂上 智代,Sakagami Tomoyo,10,14,161,47,O,86,57,82,E,CLA_TOM.png,,CLANNAD/智代アフター,桑島 法子,slk000,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
 Y,伊吹 風子,Ibuki Fūko,7,20,150,41,B,78,54,79,A,CLA_FUK.png,,CLANNAD,野中 藍,slk000/JimRaynor,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
 Y,宮沢 有紀寧,Miyazawa Yukine,8,7,157,45,A,不明,不明,不明,Est. B,CLA_YUK.png,,CLANNAD,榎本 温子,slk000/JimRaynor,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
-Y,藤林 椋,Fujibayashi Ryou,9,9,159,47,O,不明,不明,不明,Est. D,CLA_RYO.png,,CLANNAD,神田 朱未,slk000/JimRaynor,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
+Y,藤林 椋,Fujibayashi Ryou,9,9,159,47,O,85,56,83,E,CLA_RYO.png,,CLANNAD,神田 朱未,slk000/JimRaynor,http://ja.wikipedia.org/wiki/CLANNAD_(%E3%82%B2%E3%83%BC%E3%83%A0)
 Y,相楽 美佐枝,Sagara Misae,4,3,166,51,B,不明,不明,不明,Est. E,CLA_MIS.png,,CLANNAD,雪野 五月,幾星霜の観測者/JimRaynor,http://zh.wikipedia.org/wiki/CLANNAD
 Y,春原 芽衣,Sunohara Mei,6,11,152,42,A,不明,不明,不明,Est. A,CLA_MEI.png,,CLANNAD,田村 ゆかり,幾星霜の観測者/JimRaynor,http://zh.wikipedia.org/wiki/CLANNAD
 Y,古河 早苗,Furukawa Sanae,10,5,158,45,A,不明,不明,不明,Est. C,CLA_SAN.png,,CLANNAD,井上 喜久子,幾星霜の観測者/JimRaynor,http://zh.wikipedia.org/wiki/CLANNAD


### PR DESCRIPTION
更新藤林椋確定的三圍，魁老師於日本時間9/2晚公佈當年的設定數據。也順便修正了一下兩位的Cup size。
